### PR TITLE
Hide section links with zero search results

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
         }
 
         .blocks-nav button.dimmed {
-          opacity: 0.3;
+          display: none;
         }
 
         .results {


### PR DESCRIPTION
Fixes #4

When a search query is active, section links (block nav buttons) that have zero matching characters are now fully hidden (`display: none`) instead of just dimmed (`opacity: 0.3`). This keeps the sidebar clean and focused on only the relevant sections.

**Change:** `.blocks-nav button.dimmed` CSS rule changed from `opacity: 0.3` to `display: none`.