### PR TITLE
Fix: convert sidebar to horizontal tab strip on small screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,6 +292,31 @@
           opacity: 0.3;
         }
 
+        @media (max-width: 640px) {
+          .main {
+            flex-direction: column;
+          }
+
+          .blocks-nav {
+            display: flex;
+            flex-shrink: 0;
+            width: auto;
+            border-right: none;
+            border-bottom:
+              1px solid
+              var(--color-border-subtle);
+            overflow-x: auto;
+            overflow-y: hidden;
+            -webkit-overflow-scrolling: touch;
+          }
+
+          .blocks-nav button {
+            flex-shrink: 0;
+            width: auto;
+            white-space: nowrap;
+          }
+        }
+
         .results {
           flex: 1;
           min-height: 0;


### PR DESCRIPTION
On viewports ≤640px, the blocks sidebar reflows into a horizontally scrolling tab strip above the character grid. The grid gets the full viewport width. Desktop layout is unchanged.

Closes #2