### PR TITLE
Match space below group name to char grid gap

### DIFF
--- a/components/char-grid.js
+++ b/components/char-grid.js
@@ -1,7 +1,7 @@
 import { element, fragment } from "../lib/dom.js";
 
 const ROW_HEIGHT = 138;
-const HEADER_HEIGHT = 36;
+const HEADER_HEIGHT = 40;
 const BUFFER_ROWS = 3;
 
 export class CharGrid extends HTMLElement {


### PR DESCRIPTION
Change `HEADER_HEIGHT` from 36 to 40 so the space between the section label (28px) and the first character row is 12px, matching the grid gap (`var(--space-3)` = 0.75rem).

Fixes #10