### PR TITLE
Press Esc to clear search

### DIFF
--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -376,6 +376,13 @@ export class UnicodePicker extends HTMLElement {
       e.preventDefault();
       this.#copyChar(list[this.#selectedIndex]);
       return;
+    } else if (e.key === "Escape") {
+      if (this.#input.value) {
+        e.preventDefault();
+        this.#input.value = "";
+        this.#search("");
+      }
+      return;
     } else {
       return;
     }


### PR DESCRIPTION
When the search input has text, pressing **Esc** clears the field and resets results. If the input is already empty, default behavior is preserved.

Closes #16