### PR TITLE
Use background color to show character size, not outline

### DIFF
--- a/components/char-grid.css
+++ b/components/char-grid.css
@@ -120,6 +120,10 @@ char-grid .char-cell[aria-selected="true"] {
   background: var(--color-bg-hover);
 }
 
+char-grid .char-cell[aria-selected="true"] .char-glyph {
+  background: oklch(0.93 0.02 162 / 0.08);
+}
+
 char-grid .char-cell.copied {
   position: relative;
 }
@@ -173,7 +177,7 @@ char-grid .char-glyph {
   font-size: var(--text-glyph);
   line-height: var(--leading-tight);
   color: var(--color-text-primary);
-  border: 1px solid color-mix(in srgb, var(--color-border-subtle) 50%, transparent);
+  background: oklch(0.93 0.02 162 / 0.06);
   border-radius: var(--radius-xs, 2px);
 }
 

--- a/components/char-grid.css
+++ b/components/char-grid.css
@@ -121,7 +121,7 @@ char-grid .char-cell[aria-selected="true"] {
 }
 
 char-grid .char-cell[aria-selected="true"] .char-glyph {
-  background: oklch(0.93 0.02 162 / 0.08);
+  background: oklch(0.93 0.02 162 / 0.15);
 }
 
 char-grid .char-cell.copied {
@@ -177,7 +177,7 @@ char-grid .char-glyph {
   font-size: var(--text-glyph);
   line-height: var(--leading-tight);
   color: var(--color-text-primary);
-  background: oklch(0.93 0.02 162 / 0.06);
+  background: oklch(0.93 0.02 162 / 0.12);
   border-radius: var(--radius-xs, 2px);
 }
 


### PR DESCRIPTION
Replace the border on `.char-glyph` with a subtle background fill to indicate glyph size. The background opacity is slightly increased when the cell is selected so it remains visible against the selection highlight.

Fixes #24