### PR TITLE
Don't focus search input when clicking groups

### DIFF
--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -5,6 +5,9 @@ import "./unicode-picker.css";
 const RECENTS_KEY = "unicode-picker-recents";
 const MAX_RECENTS = 36;
 const THEME_KEY = "unicode-picker-theme";
+const IS_MAC = /Mac|iPhone|iPad/.test(
+  navigator.platform,
+);
 
 export class UnicodePicker extends HTMLElement {
   #allChars = [];
@@ -98,9 +101,8 @@ export class UnicodePicker extends HTMLElement {
     this.addEventListener(
       "keydown",
       event => {
-        const mod = /Mac|iPhone|iPad/.test(
-          navigator.platform,
-        ) ? event.metaKey : event.ctrlKey;
+        const mod = IS_MAC ?
+          event.metaKey : event.ctrlKey;
         if (event.key === "f" && mod) {
           event.preventDefault();
           this.#input.focus();

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -1,13 +1,11 @@
 import "./char-grid.js";
 import "./copy-toast.js";
 import "./unicode-picker.css";
+import { KEY, KeyListener } from "../lib/key-listener.js";
 
 const RECENTS_KEY = "unicode-picker-recents";
 const MAX_RECENTS = 36;
 const THEME_KEY = "unicode-picker-theme";
-const IS_MAC = /Mac|iPhone|iPad/.test(
-  navigator.platform,
-);
 
 export class UnicodePicker extends HTMLElement {
   #allChars = [];
@@ -71,10 +69,13 @@ export class UnicodePicker extends HTMLElement {
         this.#input.focus();
       },
     );
-    this.#input.addEventListener(
-      "keydown",
-      event => this.#onKeydown(event),
-    );
+    new KeyListener(this.#input)
+      .keydown(KEY.Down, () => this.#moveGrid("down"))
+      .keydown(KEY.Up, () => this.#moveGrid("up"))
+      .keydown(KEY.Right, () => this.#moveGrid("right"))
+      .keydown(KEY.Left, () => this.#moveGrid("left"))
+      .keydown(KEY.Enter, () => this.#copySelected())
+      .keydown(KEY.Esc, () => this.#clearSearch());
     this.#grid.addEventListener(
       "char-select",
       event => this.#copyChar(event.detail),
@@ -94,22 +95,18 @@ export class UnicodePicker extends HTMLElement {
         this.#activateBlock(btn);
       },
     );
-    this.#blocksNav.addEventListener(
-      "keydown",
-      event => this.#onNavKeydown(event),
-    );
-    this.addEventListener(
-      "keydown",
-      event => {
-        const mod = IS_MAC ?
-          event.metaKey : event.ctrlKey;
-        if (event.key === "f" && mod) {
-          event.preventDefault();
-          this.#input.focus();
-          this.#input.select();
-        }
-      },
-    );
+    new KeyListener(this.#blocksNav)
+      .keydown(KEY.Down, () => this.#moveNav(1))
+      .keydown(KEY.Right, () => this.#moveNav(1))
+      .keydown(KEY.Up, () => this.#moveNav(-1))
+      .keydown(KEY.Left, () => this.#moveNav(-1))
+      .keydown(KEY.Home, () => this.#focusNavStart())
+      .keydown(KEY.End, () => this.#focusNavEnd());
+    new KeyListener(this)
+      .keydown(KEY.Mod.f, () => {
+        this.#input.focus();
+        this.#input.select();
+      });
     this.#grid.addEventListener(
       "block-change",
       event => {
@@ -451,45 +448,33 @@ export class UnicodePicker extends HTMLElement {
     ];
   }
   
-  #onNavKeydown(event) {
+  #moveNav(delta) {
     const buttons = this.#visibleNavButtons();
     if (!buttons.length) return;
-    const current = document.activeElement;
-    const idx = buttons.indexOf(current);
-    let next;
-    
-    switch (event.key) {
-      case "ArrowDown":
-      case "ArrowRight":
-        event.preventDefault();
-        next = buttons[
-          idx + 1 < buttons.length ? idx + 1 : 0
-        ];
-        break;
-      case "ArrowUp":
-      case "ArrowLeft":
-        event.preventDefault();
-        next = buttons[
-          idx - 1 >= 0 ?
-            idx - 1 : buttons.length - 1
-        ];
-        break;
-      case "Home":
-        event.preventDefault();
-        next = buttons[0];
-        break;
-      case "End":
-        event.preventDefault();
-        next = buttons[buttons.length - 1];
-        break;
-      default:
-        return;
-    }
-    
-    if (next) {
-      this.#activateBlock(next);
-      next.focus();
-    }
+    const idx = Math.max(0,
+      buttons.indexOf(document.activeElement),
+    );
+    const next =
+      (idx + delta + buttons.length)
+      % buttons.length;
+    const btn = buttons[next];
+    this.#activateBlock(btn);
+    btn.focus();
+  }
+  
+  #focusNavStart() {
+    const btn = this.#visibleNavButtons()[0];
+    if (!btn) return;
+    this.#activateBlock(btn);
+    btn.focus();
+  }
+  
+  #focusNavEnd() {
+    const btn =
+      this.#visibleNavButtons().at(-1);
+    if (!btn) return;
+    this.#activateBlock(btn);
+    btn.focus();
   }
   
   async #copyChar(entry) {
@@ -502,60 +487,50 @@ export class UnicodePicker extends HTMLElement {
     }
   }
   
-  #onKeydown(event) {
+  #moveGrid(direction) {
     const list = this.#currentList();
-    let newIndex = this.#selectedIndex;
+    const index = this.#selectedIndex;
+    let next;
     
-    if (event.key === "ArrowDown") {
+    if (direction === "down") {
       if (!list.length) return;
-      event.preventDefault();
-      if (newIndex < 0) {
-        newIndex = 0;
-      } else {
-        newIndex =
-          this.#grid.moveDown(newIndex);
-      }
-    } else if (event.key === "ArrowUp") {
+      next = index < 0 ?
+        0 : this.#grid.moveDown(index);
+    } else if (direction === "up") {
       if (!list.length) return;
-      event.preventDefault();
-      if (newIndex < 0) {
-        newIndex = 0;
-      } else {
-        newIndex =
-          this.#grid.moveUp(newIndex);
-      }
-    } else if (event.key === "ArrowRight") {
-      event.preventDefault();
-      if (newIndex < list.length - 1) {
-        newIndex++;
-      }
-    } else if (event.key === "ArrowLeft") {
-      event.preventDefault();
-      if (newIndex > 0) {
-        newIndex--;
-      }
-    } else if (
-      event.key === "Enter" && list.length > 0
-      && this.#selectedIndex >= 0
-    ) {
-      event.preventDefault();
-      this.#copyChar(list[this.#selectedIndex]);
-      return;
-    } else if (event.key === "Escape") {
-      if (this.#input.value) {
-        event.preventDefault();
-        this.#input.value = "";
-        this.#search("");
-        this.#updateClearBtn();
-      }
-      return;
-    } else {
-      return;
+      next = index < 0 ?
+        0 : this.#grid.moveUp(index);
+    } else if (direction === "right") {
+      if (index >= list.length - 1) return;
+      next = index + 1;
+    } else if (direction === "left") {
+      if (index <= 0) return;
+      next = index - 1;
     }
     
-    if (newIndex !== this.#selectedIndex) {
-      this.#select(newIndex);
-      this.#grid.scrollToIndex(newIndex);
+    if (next !== index) {
+      this.#select(next);
+      this.#grid.scrollToIndex(next);
+    }
+  }
+  
+  #copySelected() {
+    const list = this.#currentList();
+    if (
+      list.length > 0
+      && this.#selectedIndex >= 0
+    ) {
+      this.#copyChar(
+        list[this.#selectedIndex],
+      );
+    }
+  }
+  
+  #clearSearch() {
+    if (this.#input.value) {
+      this.#input.value = "";
+      this.#search("");
+      this.#updateClearBtn();
     }
   }
 }

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -20,7 +20,7 @@ export class UnicodePicker extends HTMLElement {
   #toast;
   #blocksNav;
   #themeToggle;
-
+  
   constructor() {
     super();
     const template = document.getElementById(
@@ -29,7 +29,7 @@ export class UnicodePicker extends HTMLElement {
     this.appendChild(
       template.content.cloneNode(true),
     );
-
+    
     this.#input =
       this.querySelector("input");
     this.#clearBtn =
@@ -46,7 +46,7 @@ export class UnicodePicker extends HTMLElement {
       this.querySelector(
         ".theme-toggle input",
       );
-
+    
     this.#initTheme();
     this.#themeToggle.addEventListener(
       "change",
@@ -132,7 +132,7 @@ export class UnicodePicker extends HTMLElement {
       },
     );
   }
-
+  
   connectedCallback() {
     this.#allChars = parseUnicodeData(
       document.getElementById("unicode-data")
@@ -153,7 +153,7 @@ export class UnicodePicker extends HTMLElement {
     this.#render();
     this.#scrollBlockIntoView();
   }
-
+  
   #initTheme() {
     let saved;
     try {
@@ -170,51 +170,51 @@ export class UnicodePicker extends HTMLElement {
     this.#themeToggle.checked =
       theme === "dark";
   }
-
+  
   #onThemeToggle() {
-    const next = this.#themeToggle.checked
-      ? "dark" : "light";
+    const next = this.#themeToggle.checked ?
+      "dark" : "light";
     document.documentElement.dataset.theme =
       next;
     try {
       localStorage.setItem(THEME_KEY, next);
     } catch {}
   }
-
+  
   #buildBlocksNav() {
     const frag = document.createDocumentFragment();
     for (
-      const [i, block] of
+      const [index, block] of
       this.#blocks.entries()
     ) {
       const btn = document.createElement("button");
       btn.textContent = block.name;
       btn.dataset.index = block.startIndex;
       btn.setAttribute("role", "option");
-      btn.tabIndex = i === 0 ? 0 : -1;
+      btn.tabIndex = index === 0 ? 0 : -1;
       frag.appendChild(btn);
     }
     this.#blocksNav.appendChild(frag);
   }
-
+  
   #updateBlocksDimming() {
     const query = this.#input.value.trim();
     const buttons =
       this.#blocksNav.querySelectorAll("button");
-
+    
     if (!query) {
       for (const btn of buttons) {
         btn.disabled = false;
       }
       return;
     }
-
+    
     const matchIndices = new Set(
       this.#filtered.map(
         (entry) => this.#allChars.indexOf(entry),
       ),
     );
-
+    
     for (
       const [blockIdx, btn] of
       buttons.entries()
@@ -238,17 +238,17 @@ export class UnicodePicker extends HTMLElement {
       btn.disabled = !hasMatch;
     }
   }
-
+  
   #updateClearBtn() {
     this.#clearBtn.disabled =
       this.#input.value.length === 0;
   }
-
+  
   #select(index) {
     this.#selectedIndex = index;
     this.#grid.selectedIndex = index;
   }
-
+  
   #getRecents() {
     try {
       const raw =
@@ -258,7 +258,7 @@ export class UnicodePicker extends HTMLElement {
       return [];
     }
   }
-
+  
   #addRecent(entry) {
     const recents = this.#getRecents().filter(
       recent => recent.u !== entry.u,
@@ -272,7 +272,7 @@ export class UnicodePicker extends HTMLElement {
       JSON.stringify(recents),
     );
   }
-
+  
   #search(query) {
     if (!query.trim()) {
       this.#filtered = [];
@@ -284,7 +284,7 @@ export class UnicodePicker extends HTMLElement {
       this.#updateBlocksDimming();
       return;
     }
-
+    
     this.#clearActiveBlock();
     const terms = query.toUpperCase().split(/\s+/);
     this.#filtered = this.#allChars.filter(
@@ -302,7 +302,7 @@ export class UnicodePicker extends HTMLElement {
     );
     this.#filteredBlocks =
       this.#computeFilteredBlocks();
-
+    
     this.#status.textContent =
       `${this.#filtered.length.toLocaleString()}`
       + ` matching characters`;
@@ -310,16 +310,16 @@ export class UnicodePicker extends HTMLElement {
     this.#render();
     this.#updateBlocksDimming();
   }
-
+  
   #render() {
     const query = this.#input.value.trim();
     const list = this.#currentList();
-
+    
     if (query && list.length === 0) {
       this.#grid.showEmpty("No matches");
       return;
     }
-
+    
     const blocks = query ?
       this.#filteredBlocks :
       this.#blocks;
@@ -327,13 +327,13 @@ export class UnicodePicker extends HTMLElement {
     this.#grid.selectedIndex =
       this.#selectedIndex;
   }
-
+  
   #currentList() {
     return this.#input.value.trim() ?
       this.#filtered :
       this.#allChars;
   }
-
+  
   #buildIndexMap() {
     this.#indexMap = new Map();
     for (
@@ -343,13 +343,13 @@ export class UnicodePicker extends HTMLElement {
       this.#indexMap.set(char, idx);
     }
   }
-
+  
   #computeFilteredBlocks() {
     if (!this.#filtered.length) return [];
-
+    
     const blocks = [];
     let currentBlockIdx = -1;
-
+    
     for (
       const [idx, entry] of
       this.#filtered.entries()
@@ -358,7 +358,7 @@ export class UnicodePicker extends HTMLElement {
         this.#indexMap.get(entry);
       const blockIdx =
         this.#blockIndexFor(origIdx);
-
+      
       if (blockIdx !== currentBlockIdx) {
         blocks.push({
           startIndex: idx,
@@ -367,10 +367,10 @@ export class UnicodePicker extends HTMLElement {
         currentBlockIdx = blockIdx;
       }
     }
-
+    
     return blocks;
   }
-
+  
   #blockIndexFor(origIdx) {
     let low = 0;
     let high = this.#blocks.length - 1;
@@ -386,7 +386,7 @@ export class UnicodePicker extends HTMLElement {
     }
     return low;
   }
-
+  
   #resolveBlockIndex(origIndex) {
     if (!this.#input.value.trim()) {
       return origIndex;
@@ -401,7 +401,7 @@ export class UnicodePicker extends HTMLElement {
     return filtered ?
       filtered.startIndex : origIndex;
   }
-
+  
   #clearActiveBlock() {
     for (const btn of
       this.#blocksNav.querySelectorAll(
@@ -411,7 +411,7 @@ export class UnicodePicker extends HTMLElement {
       btn.removeAttribute("aria-current");
     }
   }
-
+  
   #scrollBlockIntoView() {
     const active =
       this.#blocksNav.querySelector(
@@ -421,7 +421,7 @@ export class UnicodePicker extends HTMLElement {
       active.scrollIntoView({ block: "nearest" });
     }
   }
-
+  
   #activateBlock(btn) {
     const index =
       this.#resolveBlockIndex(
@@ -431,16 +431,16 @@ export class UnicodePicker extends HTMLElement {
     this.#select(index);
     this.#setRovingTab(btn);
   }
-
+  
   #setRovingTab(btn) {
-    for (const b of
+    for (const other of
       this.#blocksNav.querySelectorAll("button")
     ) {
-      b.tabIndex = -1;
+      other.tabIndex = -1;
     }
     btn.tabIndex = 0;
   }
-
+  
   #visibleNavButtons() {
     return [
       ...this.#blocksNav.querySelectorAll(
@@ -448,14 +448,14 @@ export class UnicodePicker extends HTMLElement {
       ),
     ];
   }
-
+  
   #onNavKeydown(event) {
     const buttons = this.#visibleNavButtons();
     if (!buttons.length) return;
     const current = document.activeElement;
     const idx = buttons.indexOf(current);
     let next;
-
+    
     switch (event.key) {
       case "ArrowDown":
       case "ArrowRight":
@@ -483,13 +483,13 @@ export class UnicodePicker extends HTMLElement {
       default:
         return;
     }
-
+    
     if (next) {
       this.#activateBlock(next);
       next.focus();
     }
   }
-
+  
   async #copyChar(entry) {
     await navigator.clipboard.writeText(entry.c);
     this.#addRecent(entry);
@@ -499,11 +499,11 @@ export class UnicodePicker extends HTMLElement {
       this.#grid.showCopied(index);
     }
   }
-
+  
   #onKeydown(event) {
     const list = this.#currentList();
     let newIndex = this.#selectedIndex;
-
+    
     if (event.key === "ArrowDown") {
       if (!list.length) return;
       event.preventDefault();
@@ -550,7 +550,7 @@ export class UnicodePicker extends HTMLElement {
     } else {
       return;
     }
-
+    
     if (newIndex !== this.#selectedIndex) {
       this.#select(newIndex);
       this.#grid.scrollToIndex(newIndex);

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -103,7 +103,7 @@ export class UnicodePicker extends HTMLElement {
       .keydown(KEY.Home, () => this.#focusNavStart())
       .keydown(KEY.End, () => this.#focusNavEnd());
     new KeyListener(this)
-      .keydown(KEY.Mod.f, () => {
+      .keydown(KEY.Mod.F, () => {
         this.#input.focus();
         this.#input.select();
       });

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -98,10 +98,10 @@ export class UnicodePicker extends HTMLElement {
     this.addEventListener(
       "keydown",
       event => {
-        if (
-          event.key === "f"
-          && (event.metaKey || event.ctrlKey)
-        ) {
+        const mod = /Mac|iPhone|iPad/.test(
+          navigator.platform,
+        ) ? event.metaKey : event.ctrlKey;
+        if (event.key === "f" && mod) {
           event.preventDefault();
           this.#input.focus();
           this.#input.select();

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -95,6 +95,19 @@ export class UnicodePicker extends HTMLElement {
       "keydown",
       event => this.#onNavKeydown(event),
     );
+    this.addEventListener(
+      "keydown",
+      event => {
+        if (
+          event.key === "f"
+          && (event.metaKey || event.ctrlKey)
+        ) {
+          event.preventDefault();
+          this.#input.focus();
+          this.#input.select();
+        }
+      },
+    );
     this.#grid.addEventListener(
       "block-change",
       event => {

--- a/components/unicode-picker.js
+++ b/components/unicode-picker.js
@@ -89,7 +89,6 @@ export class UnicodePicker extends HTMLElement {
           return;
         }
         this.#activateBlock(btn);
-        this.#input.focus();
       },
     );
     this.#blocksNav.addEventListener(

--- a/lib/key-listener.js
+++ b/lib/key-listener.js
@@ -39,6 +39,10 @@ function matches(event, descriptor) {
   if (descriptor.mod !== modPressed) return false;
   if (descriptor.shift !== event.shiftKey) return false;
   if (descriptor.alt !== event.altKey) return false;
+  if (descriptor.key.length === 1) {
+    return event.key.toLowerCase()
+      === descriptor.key.toLowerCase();
+  }
   return event.key === descriptor.key;
 }
 

--- a/lib/key-listener.js
+++ b/lib/key-listener.js
@@ -1,0 +1,101 @@
+const IS_APPLE = /Mac|iPhone|iPad/.test(
+  navigator.platform,
+);
+
+const ALIASES = {
+  Esc: "Escape",
+  Up: "ArrowUp",
+  Down: "ArrowDown",
+  Left: "ArrowLeft",
+  Right: "ArrowRight",
+  Del: "Delete",
+  Ins: "Insert",
+};
+
+function resolveKey(name) {
+  return ALIASES[name] ?? name;
+}
+
+function descriptorFor(chain) {
+  const mods = { mod: false, shift: false, alt: false };
+  let key = null;
+  for (const part of chain) {
+    if (part === "Mod") {
+      mods.mod = true;
+    } else if (part === "Shift") {
+      mods.shift = true;
+    } else if (part === "Alt") {
+      mods.alt = true;
+    } else {
+      key = resolveKey(part);
+    }
+  }
+  return { ...mods, key };
+}
+
+function matches(event, descriptor) {
+  const modPressed = IS_APPLE ?
+    event.metaKey : event.ctrlKey;
+  if (descriptor.mod !== modPressed) return false;
+  if (descriptor.shift !== event.shiftKey) return false;
+  if (descriptor.alt !== event.altKey) return false;
+  return event.key === descriptor.key;
+}
+
+const KEY = new Proxy({}, {
+  get(_target, prop) {
+    return buildChain([prop]);
+  },
+});
+
+function buildChain(chain) {
+  const descriptor = descriptorFor(chain);
+  return new Proxy(descriptor, {
+    get(target, prop) {
+      if (prop === "key" || prop === "mod"
+        || prop === "shift" || prop === "alt") {
+        return target[prop];
+      }
+      return buildChain([...chain, prop]);
+    },
+  });
+}
+
+class KeyListener {
+  #element;
+  #bindings = [];
+  #handler;
+  
+  constructor(element) {
+    this.#element = element;
+    this.#handler = (event) => {
+      for (const [descriptor, callback] of
+        this.#bindings
+      ) {
+        if (matches(event, descriptor)) {
+          event.preventDefault();
+          callback(event);
+          return;
+        }
+      }
+    };
+    this.#element.addEventListener(
+      "keydown", this.#handler,
+    );
+  }
+  
+  keydown(descriptor, callback) {
+    this.#bindings.push([descriptor, callback]);
+    return this;
+  }
+  
+  off() {
+    this.#element.removeEventListener(
+      "keydown", this.#handler,
+    );
+    this.#bindings = [];
+    return this;
+  }
+}
+
+export { KEY, KeyListener };


### PR DESCRIPTION
Remove the `this.#input.focus()` call from the blocks nav click handler so that clicking a group no longer shifts focus to the search field.

Fixes #26