### PR TITLE
Respect mobile safe area insets (#38)

### DIFF
--- a/components/char-grid.css
+++ b/components/char-grid.css
@@ -8,7 +8,9 @@ char-grid {
 
 char-grid .scroll-container {
   flex: 1;
-  padding: 0 var(--space-3) var(--space-3);
+  padding:
+    0 var(--space-3)
+    calc(var(--space-3) + env(safe-area-inset-bottom));
   overflow-y: auto;
 }
 

--- a/components/copy-toast.css
+++ b/components/copy-toast.css
@@ -1,6 +1,6 @@
 copy-toast {
   position: fixed;
-  bottom: var(--space-6);
+  bottom: calc(var(--space-6) + env(safe-area-inset-bottom));
   left: 50%;
   z-index: 10;
   padding: var(--space-2) var(--space-6);

--- a/components/unicode-picker.css
+++ b/components/unicode-picker.css
@@ -1,7 +1,9 @@
 unicode-picker {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  height: 100dvh;
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
   overflow: hidden;
   container-type: inline-size;
 }
@@ -12,7 +14,8 @@ unicode-picker .search-bar {
   flex-direction: column;
   gap: var(--space-2);
   padding:
-    var(--space-4) var(--space-4)
+    calc(var(--space-4) + env(safe-area-inset-top))
+    var(--space-4)
     var(--space-2);
   border-bottom:
     1px solid var(--color-border-subtle);

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Unicode Picker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link

--- a/style.css
+++ b/style.css
@@ -233,7 +233,7 @@
 
 @layer base {
   body {
-    height: 100vh;
+    height: 100dvh;
     overflow: hidden;
     font-family: var(--font-ui);
     font-size: var(--text-sm);


### PR DESCRIPTION
Closes #38

## Summary
- Add `viewport-fit=cover` so the layout can extend into the safe-area regions
- Pad the outer `unicode-picker` container with `env(safe-area-inset-left/right)` so edge content (blocks nav, search bar, grid) isn't clipped by notches in landscape
- Add `env(safe-area-inset-top)` to the search-bar top padding so it clears the notch / Dynamic Island
- Add `env(safe-area-inset-bottom)` to the char-grid scroll container and the copy toast so the last row and toast stay above the home indicator and collapsible browser toolbar
- Switch `100vh` → `100dvh` on `body` and `unicode-picker` so full-height accounts for the dynamic toolbar

## Test plan
- [x] Existing visual snapshots unchanged (`node test/screenshot.js 4175`)
- [x] Verified computed padding on a 390×844 viewport: with 20/20 horizontal + 59 top + 34 bottom simulated insets, padding grows as `base + inset` (16→75, 12→46, 24→58)
- [ ] Manual check on iOS Safari in portrait and landscape